### PR TITLE
Explicitly set security protocol to TLS 1.2

### DIFF
--- a/Editor/NugetHelper.cs
+++ b/Editor/NugetHelper.cs
@@ -1540,6 +1540,7 @@ namespace FreakshowStudio.NugetForUnity.Editor
         /// <returns>Stream containing the result.</returns>
         public static Stream RequestUrl(string url, string userName, string password, int? timeOut)
         {
+            ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls12;
             HttpWebRequest getRequest = (HttpWebRequest)WebRequest.Create(url);
             if (timeOut.HasValue)
             {


### PR DESCRIPTION
This seems to be needed in Unity 2021.2.0a19 after the upgrade to mono